### PR TITLE
feat(BLK-867): Increased DefaultMaxPrice to 20k gwei

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -31,7 +31,7 @@ import (
 
 const sampleNumber = 3 // Number of transactions sampled in a block
 
-var DefaultMaxPrice = big.NewInt(500 * params.GWei)
+var DefaultMaxPrice = big.NewInt(20000 * params.GWei)
 
 type Config struct {
 	Blocks          int


### PR DESCRIPTION
### Description

There's a hardcoded DefaultMaxPrice  of 500 gwei in eth/gasprice/gasprice.go which is less than the minimum gas price that we want to use, therefore we need to increase it.

### Changes
Set `DefaultMaxPrice` to 20k gwei in `eth/gasprice/gasprice.go`