### PR TITLE
Removed Dragon8 fork for rollback

### DIFF
--- a/config/embedded/chiliz.json
+++ b/config/embedded/chiliz.json
@@ -31,7 +31,6 @@
     "grayGlacierBlock": 13189711,
     "shanghaiTime": 1716300000,
     "keplerTime": 1716300000,
-    "dragon8Time": 1716300000,
     "parlia": {
       "period": 3,
       "epoch": 28800


### PR DESCRIPTION
Something happened during Dragon8 hardfork, we need to disable the fork and rollback to pre-hardfork block. 
