### PR TITLE
Prepare Mainnet Release

### DIFF
--- a/config/embedded/chiliz.json
+++ b/config/embedded/chiliz.json
@@ -31,6 +31,7 @@
     "grayGlacierBlock": 13189711,
     "shanghaiTime": 1716300000,
     "keplerTime": 1716300000,
+    "dragon8FixTime": 1718611200,
     "parlia": {
       "period": 3,
       "epoch": 28800

--- a/params/version.go
+++ b/params/version.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	VersionMajor = 2  // Major version component of the current release
-	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 0  // Patch version component of the current release
+	VersionMinor = 2  // Minor version component of the current release
+	VersionPatch = 1  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Changes
* Updated embedded mainnet genesis config with `dragon8FixTime`.
* Set geth version to 2.2.1
