### PR TITLE
Prepare Release v2.2.3

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -577,7 +577,7 @@ func (bc *BlockChain) cacheReceipts(hash common.Hash, receipts types.Receipts, b
 		return
 	}
 	for i, receipt := range receipts {
-		receipt.EffectiveGasPrice = txs[i].EffectiveGasTipValue(block.BaseFee()) // basefee is supposed to be nil or zero
+		receipt.EffectiveGasPrice = txs[i].EffectiveGasPrice(block.BaseFee())
 	}
 
 	bc.receiptsCache.Add(hash, receipts)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -355,6 +355,11 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 	return tx.inner.gasTipCap().Cmp(other)
 }
 
+// EffectiveGasPrice returns the effective miner gas price for the given base fee.
+func (tx *Transaction) EffectiveGasPrice(basefee *big.Int) *big.Int {
+	return tx.inner.effectiveGasPrice(new(big.Int), basefee)
+}
+
 // EffectiveGasTip returns the effective miner gasTipCap for the given base fee.
 // Note: if the effective gasTipCap is negative, this method returns both 0
 //

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 2  // Major version component of the current release
-	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 1  // Patch version component of the current release
-	VersionMeta  = "" // Version metadata to append to the version string
+	VersionMajor = 2     // Major version component of the current release
+	VersionMinor = 2     // Minor version component of the current release
+	VersionPatch = 3     // Patch version component of the current release
+	VersionMeta  = "RC1" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 2     // Major version component of the current release
-	VersionMinor = 2     // Minor version component of the current release
-	VersionPatch = 3     // Patch version component of the current release
-	VersionMeta  = "RC1" // Version metadata to append to the version string
+	VersionMajor = 2  // Major version component of the current release
+	VersionMinor = 2  // Minor version component of the current release
+	VersionPatch = 3  // Patch version component of the current release
+	VersionMeta  = "" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
### Changes
- Fixed "Fixed EffectiveGasPrice only containing Tip Fee" bug.
- Bumped client version to 2.2.3