### PR TITLE
Added burn mechanism for 50% transaction fees (Part 2 of Chiliz Chall…

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -83,6 +83,8 @@ var (
 		BrunoBlock:          big.NewInt(0),
 		BerlinBlock:         big.NewInt(12_244_000),
 		Ethash:              new(EthashConfig),
+		// Block from which the burning of 50% begins (Part 2 of Chiliz  Challenge (Darío Valarezo))
+		BurnFee50Block: big.NewInt(123456789),
 	}
 
 	// MainnetTrustedCheckpoint contains the light client trusted checkpoint for the main network.
@@ -519,6 +521,9 @@ type ChainConfig struct {
 	Ethash *EthashConfig `json:"ethash,omitempty" toml:",omitempty"`
 	Clique *CliqueConfig `json:"clique,omitempty" toml:",omitempty"`
 	Parlia *ParliaConfig `json:"parlia,omitempty" toml:",omitempty"`
+
+	// Block to activate HF to burn of 50% of fees (Part 2 of Chiliz  Challenge (Darío Valarezo))
+	BurnFee50Block *big.Int `json:"burnFee50Block,omitempty"
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.


### PR DESCRIPTION
…enge Darío Valarezo)

### Description

This pull request implements a 50% transaction fee burn mechanism as part of the protocol update for the Chiliz Chain. The modification includes changes to the state processor and chain configuration to apply the burn starting from the block number:123456789

### Rationale

This is part two of the Chiliz Challenge, implementing a burn mechanism that requires forking the chain to introduce a new rule for validators
### Example

When a transaction is processed after the specified block, 50% of the transaction fees will be burned automatically, reducing the total rewards for the validator and applying the burn mechanism as part of the new protocol.

### Changes

core/state_processor.go
params/config
