### PR TITLE
Added pepper8Time to mainnet genesis config

### DIFF
--- a/config/embedded/chiliz.json
+++ b/config/embedded/chiliz.json
@@ -32,6 +32,7 @@
     "shanghaiTime": 1716300000,
     "keplerTime": 1716300000,
     "dragon8FixTime": 1718611200,
+    "pepper8Time": 1757410200,
     "parlia": {
       "period": 3,
       "epoch": 28800


### PR DESCRIPTION
### Description

Set pepper8Time to September 9th 11:30am CET (1757410200) in embedded mainnet genesis config.