### PR TITLE
Develop

### DIFF
--- a/config/embedded/chiliz.json
+++ b/config/embedded/chiliz.json
@@ -32,6 +32,7 @@
     "shanghaiTime": 1716300000,
     "keplerTime": 1716300000,
     "dragon8FixTime": 1718611200,
+    "pepper8Time": 1757410200,
     "parlia": {
       "period": 3,
       "epoch": 28800

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -41,7 +42,8 @@ func Handler(reg metrics.Registry) http.Handler {
 
 		for _, name := range names {
 			i := reg.Get(name)
-			if err := c.Add(name, i); err != nil {
+			cleanedName := strings.ReplaceAll(name, ".", "_")
+			if err := c.Add(cleanedName, i); err != nil {
 				log.Warn("Unknown Prometheus metric type", "type", fmt.Sprintf("%T", i))
 			}
 		}

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 2  // Major version component of the current release
 	VersionMinor = 5  // Minor version component of the current release
-	VersionPatch = 0  // Patch version component of the current release
+	VersionPatch = 1  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Changes
- Fixed `invalid metric type "0x31db81188a5cc391857624f668dda57ba7f2b074 gauge"` error seen in Prometheus when consuming the `/debug/metrics/prometheus` endpoint by replacing "." with "_" in metric names for prometheus.
- Bumped version number to 2.5.1.