### PR TITLE
Set SNAKE8 hard fork timestamp in Mainnet genesis config

### DIFF
--- a/config/embedded/chiliz.json
+++ b/config/embedded/chiliz.json
@@ -33,6 +33,7 @@
     "keplerTime": 1716300000,
     "dragon8FixTime": 1718611200,
     "pepper8Time": 1757410200,
+    "snake8Time": 1760432400,
     "parlia": {
       "period": 3,
       "epoch": 28800

--- a/params/version.go
+++ b/params/version.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	VersionMajor = 2  // Major version component of the current release
-	VersionMinor = 5  // Minor version component of the current release
-	VersionPatch = 1  // Patch version component of the current release
+	VersionMinor = 6  // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

This PR schedules the SNAKE8 hard fork on Chiliz Chain Mainnet on October 14, 2025 11:00am CET.

Notable changes: 
- Set `snake8Time` in mainnet genesis config.
- Bumped geth version to 2.6.0