### PR TITLE
feat(COR-21, COR-23): Cancun, Prague, Pascal mainnet

### DIFF
--- a/config/embedded/chiliz.json
+++ b/config/embedded/chiliz.json
@@ -34,9 +34,24 @@
     "dragon8FixTime": 1718611200,
     "pepper8Time": 1757410200,
     "snake8Time": 1760432400,
+    "cancunTime": 1782810000,
+    "PragueTime": 1782811800,
+    "PascalTime": 1782811800,
     "parlia": {
       "period": 3,
       "epoch": 28800
+    },
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      }
     }
   },
   "nonce": "0x0",

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 2  // Major version component of the current release
 	VersionMinor = 8  // Minor version component of the current release
-	VersionPatch = 0  // Patch version component of the current release
+	VersionPatch = 1  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 2  // Major version component of the current release
 	Minor = 8  // Minor version component of the current release
-	Patch = 0  // Patch version component of the current release
+	Patch = 1  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
**Changes:**
- Sets cancun, prague and pascal fork timestamps in mainnet config
  - Cancun: Tue Jun 30 2026 11:00:00 CEST
  - Prague & Pascal: Tue Jun 30 2026 11:30:00 CEST
- Bumps version to 2.8.1